### PR TITLE
053118 minor update

### DIFF
--- a/flipper/liteMap.py
+++ b/flipper/liteMap.py
@@ -12,8 +12,6 @@ import copy
 
 import astropy.wcs
 import astropy.io.fits as pyfits
-#import astropy.wcs as pywcs
-#import pyfits
 import flipper.fft as fftfast
 
 import astLib
@@ -26,7 +24,7 @@ import flTrace
 import healpy
 import utils
 import time
-from scipy.interpolate import splrep,splev
+from scipy.interpolate import interp1d
 class gradMap:
     """
     @brief  Class describing gradient of a liteMap
@@ -111,19 +109,10 @@ class liteMap:
         iy, ix = np.mgrid[0:Ny,0:Nx]
         modLMap[iy,ix] = np.sqrt(ly[iy]**2+lx[ix]**2)
         
-        s = splrep(ell,Cell,k=3)
-        
         ll = np.ravel(modLMap)
-        kk = splev(ll,s)
+        kk = interp1d(ell, Cell, bounds_error=False, fill_value=0.)(ll)
         id = np.where(ll>ell.max())
-        kk[id] = 0.
-        #add a cosine ^2 falloff at the very end
-        #id2 = np.where( (ll> (ell.max()-500)) & (ll<ell.max()))
-        #lEnd = ll[id2]
-        #kk[id2] *= np.cos((lEnd-lEnd.min())/(lEnd.max() -lEnd.min())*np.pi/2)
-        
-        #pylab.loglog(ll,kk)
-        
+        kk[id] = 0         
 
         area = Nx*Ny*self.pixScaleX*self.pixScaleY
         p = np.reshape(kk,[Ny,Nx]) /area * (Nx*Ny)**2
@@ -174,23 +163,10 @@ class liteMap:
         if bufferFactor > 1:
             ell = np.ravel(twodPower.modLMap)
             Cell = np.ravel(twodPower.powerMap)
-            print ell
-            print Cell
-            s = splrep(ell,Cell,k=3)
-        
-            
             ll = np.ravel(modLMap)
-            kk = splev(ll,s)
-            
-            
+            kk = interp1d(ell, Cell, bounds_error=False, fill_value=0.)(ll)
             id = np.where(ll>ell.max())
-            kk[id] = 0.
-            # add a cosine ^2 falloff at the very end
-            # id2 = np.where( (ll> (ell.max()-500)) & (ll<ell.max()))
-            # lEnd = ll[id2]
-            # kk[id2] *= np.cos((lEnd-lEnd.min())/(lEnd.max() -lEnd.min())*np.pi/2)
-            
-            # pylab.loglog(ll,kk)
+            kk[id] = 0         
 
             area = Nx*Ny*self.pixScaleX*self.pixScaleY
             p = np.reshape(kk,[Ny,Nx]) /area * (Nx*Ny)**2

--- a/flipper/liteMap.py
+++ b/flipper/liteMap.py
@@ -541,7 +541,14 @@ class liteMap:
         assert(unit in ['deg', 'rad'])
         return self.area if unit is 'deg' else self.area * (np.pi/180.)**2
 
+    def getExtent(self, unit='deg'):
+        # return x-axis, y-axis extension (i.e. width and height of the map)
+        assert(unit in ['deg', 'rad'])
 
+        extent = [self.Nx*self.pixScaleX, self.Ny*self.pixScaleY]
+        if unit is 'deg': extent = [ x * (180./np.pi) for x in extent]
+
+        return extent
 
 def liteMapsFromEnlibFits(fname):
     hdu = pyfits.open(fname)[0]


### PR DESCRIPTION
fillWithGaussianRandomField() fails sometimes because scipy spline interpolation routines (splrep,splev) can return superfluous negative values (it's not clear why this is the case.) I swapped them with scipy interp1d which seem to be more stable. 