### PR TITLE
Python3 compatibility

### DIFF
--- a/bin/generateBinFile.py
+++ b/bin/generateBinFile.py
@@ -15,7 +15,7 @@ import numpy as np
 #
 
 def __terminate__():
-    print "terminate process"
+    print("terminate process")
     sys.exit()
 
 argparser = argparse.ArgumentParser(
@@ -51,21 +51,21 @@ output_file = os.path.join(output_dir, output_file)
 
 #basic validation
 if(lmin < 0.0):
-    print 'lmin has to be equal to or greater than 0'
+    print('lmin has to be equal to or greater than 0')
     __terminate__()
 elif(lmax <= lmin):
-    print 'lmax must be bigger than lmin'
+    print('lmax must be bigger than lmin')
     __terminate__()
 elif(delta_l <= 0.0):
-    print 'step size must be bigger than 0'
+    print('step size must be bigger than 0')
     __terminate__() 
 else:
     pass
 
 nbin = int(np.floor((lmax - lmin) / delta_l)) # number of bins
 
-print "Binning File %s, lmin %0.2f, lmax %0.2f, binsize %0.2f, # bins %d" \
-        %(output_file, lmin, lmax, delta_l, nbin)
+print("Binning File %s, lmin %0.2f, lmax %0.2f, binsize %0.2f, # bins %d" \
+        %(output_file, lmin, lmax, delta_l, nbin))
 
 with open(output_file, "wb") as handle:
     handle.write(str(nbin) + '\n') # write number of bin

--- a/bin/printMapInfo
+++ b/bin/printMapInfo
@@ -3,7 +3,7 @@
 from flipper import *
 
 if len(sys.argv) == 1:
-    print "Usage: printMapInfo map.fits"
+    print("Usage: printMapInfo map.fits")
     sys.exit()
 
 m = liteMap.liteMapFromFits(sys.argv[1])

--- a/flipper/fft.py
+++ b/flipper/fft.py
@@ -174,7 +174,7 @@ def nearest_product(n, factors, direction="below"):
 	a = np.zeros(nmax+1,dtype=bool)
 	a[1] = True
 	best = 1
-	for i in xrange(n+1):
+	for i in range(n+1):
 		if not a[i]: continue
 		for f in factors:
 			m = i*f

--- a/flipper/fftTools.py
+++ b/flipper/fftTools.py
@@ -22,8 +22,8 @@ import sys, os
 from .utils import *
 from . import flTrace
 import astropy.io.fits as pyfits
-#import pyfits
 
+# Why not flipper.__path__ ?
 __FLIPPER_DIR__ = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
 
 class fft2D:
@@ -244,7 +244,8 @@ def fftFromLiteMap(liteMap,applySlepianTaper = False,nresForSlepian=3.0):
     ly =  2*np.pi  * fftfreq( ft.Ny, d = ft.pixScaleY )
     
     ix = np.mod(np.arange(ft.Nx*ft.Ny),ft.Nx)
-    iy = np.arange(ft.Nx*ft.Ny)/ft.Nx
+    # This was dividing ints, so change below needed to maintain same behaviour in python3
+    iy = np.array(np.arange(ft.Nx*ft.Ny)/ft.Nx, dtype = int)     
     
     modLMap = np.zeros([ft.Ny,ft.Nx])
     modLMap[iy,ix] = np.sqrt(lx[ix]**2 + ly[iy]**2)

--- a/flipper/fftTools.py
+++ b/flipper/fftTools.py
@@ -5,7 +5,7 @@ d@file ffTools.py
 """
 
 import numpy as np
-import utils
+from . import utils
 try:
     import pylab
 except:
@@ -19,8 +19,8 @@ from scipy.interpolate import splrep, splev
 import scipy
 import pickle
 import sys, os
-from utils import *
-import flTrace
+from .utils import *
+from . import flTrace
 import astropy.io.fits as pyfits
 #import pyfits
 
@@ -377,10 +377,10 @@ class power2D:
         """
         lxMap = self.modLMap.copy()*0.
         lyMap = self.modLMap.copy()*0.
-        for p in xrange(self.Ny):
+        for p in range(self.Ny):
             lxMap[p,:] = self.lx[:]
             
-        for q in xrange(self.Nx):
+        for q in range(self.Nx):
             lyMap[:,q] = self.ly[:]
         
         lxMap = np.ravel(lxMap)
@@ -410,7 +410,7 @@ class power2D:
         thet=[]
         wet = []
         
-        for i in xrange(len(thetas)):
+        for i in range(len(thetas)):
             
             thisWeight = 1.0
             #if thetas[i] <0.:
@@ -503,7 +503,7 @@ class power2D:
         """
         binLower,binUpper,binCenter = readBinningFile(binningFile)
         nBins = binLower.size
-        print "nBins",nBins
+        print("nBins",nBins)
         if forceContiguousBins:
             assert(nearestIntegerBinning == False)
             # redefine bin upper
@@ -515,7 +515,7 @@ class power2D:
         binMean = np.zeros(nBins)
         binSd =  np.zeros(nBins)
         binWeight = np.zeros(nBins)
-        for i in xrange(nBins):
+        for i in range(nBins):
             if noCutBelowL != None:
                 if binUpper[i]<noCutBelowL:
                     (binMean[i],binSd[i]) = self.meanPowerInAnnulus(binLower[i],binUpper[i],\
@@ -561,7 +561,7 @@ class power2D:
         if nPix>0:
             p = (np.sum(cls[idx]*wtheta[idx]) - (cls[idx].mean())*(wtheta[idx].sum()))/(np.mean(cls[idx]))
         else:
-            print 'nPix is zero: no observation in bin (%f,%f)'%(lLower,lUpper)
+            print('nPix is zero: no observation in bin (%f,%f)'%(lLower,lUpper))
             p = 0.
         return p, nPix
         
@@ -582,7 +582,7 @@ class power2D:
         binMean = np.zeros(nBins)
         binWeight = np.zeros(nBins)
         
-        for i in xrange(nBins):
+        for i in range(nBins):
             (binMean[i],binWeight[i]) = self._testIsotropyInAnnulus(binLower[i],binUpper[i],cutByMask=cutByMask)
             
         return binLower,binUpper,binCenter,binMean,binWeight
@@ -706,7 +706,7 @@ class power2D:
             binLower,binUpper,binCenter= readBinningFile(showBinsFromFile)
             theta = np.arange(0,2.*np.pi+0.05,0.05)
             
-            for i in xrange(len(binLower)):
+            for i in range(len(binLower)):
                 x,y = binUpper[i]*np.cos(theta),binUpper[i]*np.sin(theta)
                 pylab.plot(x,y,'k')
 
@@ -823,7 +823,7 @@ def binTheoryPower(l,cl,binningFile):
     lBin = np.zeros(nBins)
     clBin =  np.zeros(nBins)
                
-    for i in xrange(len(binCenter)):
+    for i in range(len(binCenter)):
         idx = np.where((l<binUpper[i]) & (l>binLower[i]))
         lBin[i] = (l[idx]).mean()
         clBin[i] = (cl[idx]).mean()
@@ -864,7 +864,7 @@ def plotBinnedPower(lbin,plbin,\
     else:
         lth=[]
         clth=[]
-    print " In fftTools: %f ******* "%yFactor
+    print(" In fftTools: %f ******* "%yFactor)
     #beamLFactor = exp(-lth*(lth+1.)*(beamFWHM/60.*np.pi/180.)**2/(8.*np.log(2.))) 
     
     
@@ -891,7 +891,7 @@ def plotBinnedPower(lbin,plbin,\
             pass
         if ylog:
             if len(negIndex[0])>0:
-                print "negIndex **********", negIndex
+                print("negIndex **********", negIndex)
                 pylab.errorbar(lbin[negIndex],-l2pl2pi[negIndex],\
                                yerr=yFactor*lbin[negIndex]**2\
                                /(2*np.pi)*errorBars[negIndex],fmt=None)
@@ -1028,7 +1028,7 @@ def readBinningFile(binningFile):
         binningFile = os.path.join(__FLIPPER_DIR__, 'params', binningFile)  
 
         if not (os.path.exists(binningFile)):
-            raise IOError, 'Binning file %s not found'%binningFile
+            raise IOError('Binning file %s not found'%binningFile)
         
     binLower,binUpper,binCenter= np.loadtxt(binningFile,skiprows=1,unpack=True)
     return binLower,binUpper,binCenter

--- a/flipper/flTrace.py
+++ b/flipper/flTrace.py
@@ -11,7 +11,7 @@ def getLevel( traceName ):
     @param traceName string - the name of the trace
     @return integer - trace verbosity level
     """
-    if traceName in traceDict.keys():
+    if traceName in list(traceDict.keys()):
         level = traceDict[traceName]
     else:
         level = traceDict[default]
@@ -39,4 +39,4 @@ def issue( traceName, level, message ):
     curLevel = getLevel(traceName)
     if level <= curLevel:
         space = " "*level
-        print "%s%s: %s" % (space, traceName, message)
+        print("%s%s: %s" % (space, traceName, message))

--- a/flipper/flipperDict.py
+++ b/flipper/flipperDict.py
@@ -2,7 +2,7 @@ import os
 import string
 
 def ask_for( key ):
-    s = raw_input( "flipperDict: enter value for '%s': " % key )
+    s = input( "flipperDict: enter value for '%s': " % key )
     try:
         val = eval(s)
     except NameError:
@@ -22,9 +22,9 @@ class flipperDict( dict ):
     def __getitem__( self, key ):
         if key not in self:
             if self.ask:
-                print "flipperDict: parameter '%s' not found" % key
+                print("flipperDict: parameter '%s' not found" % key)
                 val = ask_for( key )
-                print "flipperDict: setting '%s' = %s" % (key,repr(val))
+                print("flipperDict: setting '%s' = %s" % (key,repr(val)))
                 dict.__setitem__( self, key, val )
             else:
                 return None
@@ -51,15 +51,15 @@ class flipperDict( dict ):
             else:
                 line = string.join([old, s[0]])
                 old = ''
-            for i in xrange(len(line)):
+            for i in range(len(line)):
                 if line[i]!=' ':
                     line = line[i:]
                     break
             exec(line)
             s = line.split('=')
             if len(s) != 2:
-                print "Error parsing line:"
-                print line
+                print("Error parsing line:")
+                print(line)
                 continue
             key = s[0].strip()
             val = eval(s[1].strip()) # XXX:make safer
@@ -70,7 +70,7 @@ class flipperDict( dict ):
 
     def write_to_file( self, filename, mode = 'w' ):
         f = open( filename, mode )
-        keys = self.keys()
+        keys = list(self.keys())
         keys.sort()
         for key in keys:
             f.write( "%s = %s\n" % (key,repr(self[key])) )
@@ -81,7 +81,7 @@ class flipperDict( dict ):
     def cmp( self, otherDict ):
         
         diff = []
-        ks = self.keys()
+        ks = list(self.keys())
         for k in ks:
             try:
                 if otherDict[k] == self.params[k]:

--- a/flipper/liteMap.py
+++ b/flipper/liteMap.py
@@ -19,12 +19,12 @@ import flipper.fft as fftfast
 import astLib
 from astLib import astWCS
 from astLib import astCoords
-from utils import *
-from fftTools import fftFromLiteMap
-import fftTools
-import flTrace
+from .utils import *
+from .fftTools import fftFromLiteMap
+from . import fftTools
+from . import flTrace
 import healpy
-import utils
+from . import utils
 import time
 from scipy.interpolate import splrep,splev
 class gradMap:
@@ -67,21 +67,21 @@ class liteMap:
         @brief pretty print informstion sbout the litMap
         """
         arcmin = 180*60./np.pi
-        print "Dimensions (Ny,Nx) = (%d,%d)"%(self.Ny,self.Nx)
-        print "Pixel Scales: (%f,%f) arcmins. "%(self.pixScaleY*arcmin,self.pixScaleX*arcmin)
-        print "Map Bounds: [(x0,y0), (x1,y1)]: [(%f,%f),(%f,%f)] (degrees)"%(self.x0,self.y0,self.x1,self.y1)
-        print "Map Bounds: [(x0,y0), (x1,y1)]: [(%s,%s),(%s,%s)]"%\
+        print("Dimensions (Ny,Nx) = (%d,%d)"%(self.Ny,self.Nx))
+        print("Pixel Scales: (%f,%f) arcmins. "%(self.pixScaleY*arcmin,self.pixScaleX*arcmin))
+        print("Map Bounds: [(x0,y0), (x1,y1)]: [(%f,%f),(%f,%f)] (degrees)"%(self.x0,self.y0,self.x1,self.y1))
+        print("Map Bounds: [(x0,y0), (x1,y1)]: [(%s,%s),(%s,%s)]"%\
               (astCoords.decimal2hms(self.x0,':'),\
                astCoords.decimal2dms(self.y0,':'),\
                astCoords.decimal2hms(self.x1,':'),\
-               astCoords.decimal2dms(self.y1,':'))
+               astCoords.decimal2dms(self.y1,':')))
         
-        print "Map area = %f sq. degrees."%(self.area)
-        print "Map mean = %f"%(self.data.mean())
-        print "Map std = %f"%(self.data.std())
+        print("Map area = %f sq. degrees."%(self.area))
+        print("Map mean = %f"%(self.data.mean()))
+        print("Map std = %f"%(self.data.std()))
         
         if showHeader:
-            print "Map header \n %s"%(self.header)
+            print("Map header \n %s"%(self.header))
 
 
     def fillWithGaussianRandomField(self,ell,Cell,bufferFactor = 1):
@@ -174,8 +174,8 @@ class liteMap:
         if bufferFactor > 1:
             ell = np.ravel(twodPower.modLMap)
             Cell = np.ravel(twodPower.powerMap)
-            print ell
-            print Cell
+            print(ell)
+            print(Cell)
             s = splrep(ell,Cell,k=3)
         
             
@@ -452,7 +452,7 @@ class liteMap:
         thOut = []
         phOut = []
         if hpCoords != "J2000":
-            for i in xrange(len(th)):
+            for i in range(len(th)):
                 crd = astCoords.convertCoords("J2000", hpCoords, ph[i], th[i], 0.)
                 phOut.append(crd[0])
                 thOut.append(crd[1])
@@ -701,7 +701,7 @@ def addLiteMapsWithSpectralWeighting( liteMap1, liteMap2, kMask1Params = None, k
         liteMap2.data[:] = (liteMap2.data - signalMap.data)[:]
     np1 = fftTools.powerFromLiteMap(liteMap1)#, applySlepianTaper = True)
     np2 = fftTools.powerFromLiteMap(liteMap2)#), applySlepianTaper = True)
-    print "testing", liteMap1.data == data1
+    print("testing", liteMap1.data == data1)
     liteMap1.data[:] = data1[:]
     liteMap2.data[:] = data2[:]
 
@@ -885,8 +885,8 @@ def getCoordinateArrays( m ):
     """
     ra = np.copy(m.data)
     dec = np.copy(m.data)
-    for i in xrange(m.Ny):
-        for j in xrange(m.Nx):
+    for i in range(m.Ny):
+        for j in range(m.Nx):
             ra[i,j], dec[i,j] = m.pixToSky(j,i)
     return ra, dec
 
@@ -909,8 +909,8 @@ def resampleFromHiResMap(highResMap, lowResTemp):
     w = lowResTemp.copy()
     m.data[:] = 0.
     w.data[:] = 0.
-    for i in xrange(highResMap.Ny):
-        for j in xrange(highResMap.Nx):
+    for i in range(highResMap.Ny):
+        for j in range(highResMap.Nx):
             ra, dec = highResMap.pixToSky(j,i)
             ix,iy = [int(ind) for ind in m.skyToPix(ra,dec)]
             m.data[iy,ix] += highResMap.data[i,j]

--- a/flipper/liteMap.py
+++ b/flipper/liteMap.py
@@ -27,6 +27,7 @@ import healpy
 from . import utils
 import time
 from scipy.interpolate import splrep,splev
+
 class gradMap:
     """
     @brief  Class describing gradient of a liteMap
@@ -568,13 +569,13 @@ def liteMapsFromEnlibFits(fname):
 
     return res.reshape(d.shape[:-2])
 
-def liteMapFromFits(file,extension=0):
+def liteMapFromFits(fileName,extension=0):
     """
     @brief Reads in a FITS file and creates a liteMap object out of it.
     @param extension specify the FITS HDU where the map image is stored
     """
     ltmap = liteMap()
-    hdulist = pyfits.open(file)
+    hdulist = pyfits.open(fileName)
     header = hdulist[extension].header
     flTrace.issue('flipper.liteMap',3,"Map header \n %s"%header)
     
@@ -582,7 +583,7 @@ def liteMapFromFits(file,extension=0):
 
     [ltmap.Ny,ltmap.Nx] = ltmap.data.shape
 
-    wcs = astLib.astWCS.WCS(file,extensionName = extension)
+    wcs = astLib.astWCS.WCS(fileName,extensionName = extension)
     ltmap.wcs = wcs.copy()
     ltmap.header = ltmap.wcs.header
     ltmap.x0,ltmap.y0 = wcs.pix2wcs(0,0)
@@ -600,10 +601,10 @@ def liteMapFromFits(file,extension=0):
     #print 0.5*(ltmap.y0+ltmap.y1)
     ltmap.area = ltmap.Nx*ltmap.Ny*ltmap.pixScaleX*ltmap.pixScaleY*(180./np.pi)**2
     #print np.cos(np.pi/180.*0.5*(ltmap.y0+ltmap.y1))
-    flTrace.issue('flipper.liteMap',1,'Reading file %s'%file)
-    flTrace.issue("flipper.liteMap",1, "Map dimensions (Ny,Nx) %d %d"%\
+    flTrace.issue('flipper.liteMap',1,'Reading file %s' % (fileName))
+    flTrace.issue("flipper.liteMap",1, "Map dimensions (Ny,Nx) %d %d" %\
                 (ltmap.Ny,ltmap.Nx))
-    flTrace.issue("flipper.liteMap",1, "pixel scales Y, X (degrees) %f %f"%\
+    flTrace.issue("flipper.liteMap",1, "pixel scales Y, X (degrees) %f %f" %\
                 (ltmap.pixScaleY*180./np.pi,ltmap.pixScaleX*180./np.pi))
     
     return ltmap
@@ -637,7 +638,6 @@ def liteMapFromDataAndWCS(data,wcs):
     #print 0.5*(ltmap.y0+ltmap.y1)
     ltmap.area = ltmap.Nx*ltmap.Ny*ltmap.pixScaleX*ltmap.pixScaleY*(180./np.pi)**2
     #print np.cos(np.pi/180.*0.5*(ltmap.y0+ltmap.y1))
-    flTrace.issue('flipper.liteMap',1,'Reading file %s'%file)
     flTrace.issue("flipper.liteMap",1, "Map dimensions (Ny,Nx) %d %d"%\
                 (ltmap.Ny,ltmap.Nx))
     flTrace.issue("flipper.liteMap",1, "pixel scales Y, X (degrees) %f %f"%\

--- a/flipper/mtm.py
+++ b/flipper/mtm.py
@@ -2,8 +2,8 @@ import numpy
 import sys
 import os
 import pylab
-import fftTools
-import utils
+from . import fftTools
+from . import utils
 import trace
 
 class mtm:
@@ -41,7 +41,7 @@ class mtm:
         if self.Niter == 0:
             weights[:,:,:,:] = 1.
         else:
-            for k in xrange(self.Ntap*self.Ntap):
+            for k in range(self.Ntap*self.Ntap):
                 i = k/self.Ntap
                 j = numpy.mod(k,self.Ntap)
                 
@@ -78,13 +78,13 @@ class mtm:
         if self.Niter == 0:
             num_iter = 1
 
-        for k in  xrange(num_iter):
+        for k in  range(num_iter):
             trace.issue('mtm',2,'Iteration ...%02d'%k)
             weights = self._getWeights(p2dBest)
             p2d.powerMap[:] = 0.
             totWeight[:] = 0.
-            for i in xrange(self.Ntap):
-                for j in xrange(self.Ntap):
+            for i in range(self.Ntap):
+                for j in range(self.Ntap):
                                     
                     tempMap = self.map.copy()
                     tempMap2 = self.map2.copy()

--- a/flipper/prewhitener.py
+++ b/flipper/prewhitener.py
@@ -1,9 +1,9 @@
-import liteMap
+from . import liteMap
 import numpy
 import scipy.special as sp
-import utils
+from . import utils
 import pylab
-import flTrace
+from . import flTrace
 
 def discDiffLspace(radius,ell):
     radiusRadian = radius*numpy.pi/(180.*60.)

--- a/flipper/utils.py
+++ b/flipper/utils.py
@@ -27,8 +27,8 @@ def slepianTapers(Ny,Nx,Nres,Ntap):
     eigs = numpy.zeros([Ntap,Ntap])
     v0,sig0 = dpssFast(Nx,Nres*1.0/Nx,Ntap-1)
     v1,sig1 = dpssFast(Ny,Nres*1.0/Ny,Ntap-1)
-    for i in xrange(Ntap):
-        for j in xrange(Ntap):
+    for i in range(Ntap):
+        for j in range(Ntap):
             tapers[:,:,i,j] = numpy.outer(v1[:,i],v0[:,j])
             eigs[i,j] = sig0[i]*sig1[j]
     tapers *= numpy.sqrt(Ny*Nx*1.0)
@@ -63,10 +63,10 @@ def slepianTaper00(Nx,Ny,Nres):
         w0 = dpss0Fast(Nx,Nres*1.0/Nx)
         w1 = dpss0Fast(Ny,Nres*1.0/Ny)
     except:
-        print 'Switching to slower algorithm for Taper generation.'
-        print 'Retry after running: '
-        print 'f2py -c dpss.f -m dpss'
-        print 'in the python/ directory in flipper'
+        print('Switching to slower algorithm for Taper generation.')
+        print('Retry after running: ')
+        print('f2py -c dpss.f -m dpss')
+        print('in the python/ directory in flipper')
         w0 = dpss0(Nx,Nres*1.0/Nx)
         w1 = dpss0(Ny,Nres*1.0/Ny)
     taper = numpy.outer(w1,w0)*numpy.sqrt(Nx*Ny*1.0)
@@ -109,19 +109,19 @@ def discKern(semiY,semiX):
     @ param semiX semiMajor axis (number of pixels)
     
     """
-    print "in discKern: SemiY, SemiX", semiY, semiX
+    print("in discKern: SemiY, SemiX", semiY, semiX)
     assert(semiY > 0)
     assert(semiX > 0)
     sizeY = int(2*semiY+0.5)
     sizeX = int(2*semiX+0.5)
-    print "sizes",sizeY,sizeX
+    print("sizes",sizeY,sizeX)
     y, x = scipy.mgrid[-sizeY:sizeY+1, -sizeX:sizeX+1]
     g = numpy.zeros(y.shape)
     
     #print y, x
     nRand = 1000000
     rand = numpy.random.rand(nRand,2)
-    for i in xrange(y.shape[0]*y.shape[1]):
+    for i in range(y.shape[0]*y.shape[1]):
         mtric = ((rand[:,0] - (y.flatten())[i] -0.5)/(semiY*1.0))**2\
                 + ((rand[:,1] - (x.flatten())[i]-0.5)/(semiX*1.0))**2
         idd = numpy.where(mtric <1.)
@@ -187,7 +187,7 @@ def bin( x, y, dx, xMin = None, xMax = None ):
     binCnts = numpy.zeros(nBin, dtype = float)
     binStds = numpy.zeros(nBin, dtype = float)
  
-    for i in xrange(nBin):
+    for i in range(nBin):
         binBool = (x > binGinnings[i]) * (x < binGinnings[i] + dx)
         if not binBool.any():
             continue
@@ -238,7 +238,7 @@ def bin( x, y, dx, xMin = None, xMax = None ):
     binCnts = numpy.zeros(nBin, dtype = float)
     binStds = numpy.zeros(nBin, dtype = float)
  
-    for i in xrange(nBin):
+    for i in range(nBin):
         binBool = (x > binGinnings[i]) * (x < binGinnings[i] + dx)
         if not binBool.any():
             continue


### PR DESCRIPTION
Changes to make flipper compatible with Python3

- ran 2to3 tool to change as many things as possible automatically
- fixed fftTools and liteMap (used by nemo) to work in python3

Nemo (https://github.com/ACTCollaboration/nemo) is working as expected when using python 3.5 / python 3.6 with these changes. However, I have not tested everything that flipper does - only the routines used by Nemo.